### PR TITLE
Implemented micro:library command and blueprint

### DIFF
--- a/blueprints/micro-library/files/index.js
+++ b/blueprints/micro-library/files/index.js
@@ -1,0 +1,30 @@
+/* jshint node: true */
+'use strict';
+
+var path = require('path');
+var Funnel = require('broccoli-funnel');
+
+module.exports = {
+  name: '<%= libraryName %>',
+
+  treeForApp: function() {
+    return this.buildTree(this.root, ['library.js']);
+  },
+
+  buildTree: function(sourceTree, includedFiles) {
+    var addon = this;
+
+    return new Funnel(sourceTree, {
+      include: includedFiles,
+      getDestinationPath: function(relativePath) {
+        return addon.mapFile(relativePath);
+      }
+    });
+  },
+
+  mapFile: function(relativePath) {
+    if (relativePath === 'library.js') {
+      return path.join('lib', this.name + '.js');
+    }
+  }
+};

--- a/blueprints/micro-library/files/library.js
+++ b/blueprints/micro-library/files/library.js
@@ -1,0 +1,3 @@
+export default function () {
+  console.log('Implement your library in this file');
+};

--- a/blueprints/micro-library/files/package.json
+++ b/blueprints/micro-library/files/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "<%= libraryName %>",
+  "version": "0.0.0",
+  "description": "An ember-cli micro-library",
+  "repository": "",
+  "engines": {
+    "node": ">= 0.10.0"
+  },
+  "dependencies": {
+    "broccoli-funnel": "^0.2.3"
+  },
+  "keywords": [
+    "ember-addon",
+    "ember-micro-addon",
+    "ember-micro-library"
+  ]
+}

--- a/blueprints/micro-library/index.js
+++ b/blueprints/micro-library/index.js
@@ -1,0 +1,13 @@
+module.exports = {
+  description: 'The default blueprint for ember-cli micro-addon library.',
+
+  locals: function(options) {
+    var libraryEntity = options.entity;
+    var libraryName = libraryEntity.name;
+
+    return {
+      libraryName: libraryName,
+      emberCLIVersion: require('../../package').version,
+    };
+  },
+};

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -1,4 +1,5 @@
 module.exports = {
   'micro:hello': require('./hello'),
-  'micro:component': require('./component')
+  'micro:component': require('./component'),
+  'micro:library': require('./library')
 };

--- a/lib/commands/library.js
+++ b/lib/commands/library.js
@@ -1,0 +1,13 @@
+module.exports = {
+  name: 'micro:library',
+  description: 'Creates files required for a micro-library to work',
+  works: 'outsideProject',
+
+  validateAndRun: function(rawArgs) {
+    return this.run({}, rawArgs);
+  },
+
+  run: function(options, rawArgs) {
+    return require('../tasks/library')(rawArgs, this.project);
+  }
+};

--- a/lib/tasks/library.js
+++ b/lib/tasks/library.js
@@ -1,0 +1,20 @@
+/*jshint node:true*/
+'use strict';
+
+var Promise = require('../ext/promise');
+var runCommand = require('../utils/run-command');
+
+module.exports = function(rawArgs, project) {
+
+  var name = rawArgs[0];
+  if (name) {
+    var command = 'ember new ' + name + ' --blueprint ./node_modules/ember-micro-addon/blueprints/micro-library --skip-npm --skip-bower --skip-git'
+    var msg = 'Creating micro-component in ./' + name
+    return runCommand(command, msg, {
+      cwd: project.root
+    })();
+  } else {
+    return Promise.reject(new Error('A "name" parameter is required to generate a micro-library'));
+  }
+
+};


### PR DESCRIPTION
- [Asana task: ember micro library](https://app.asana.com/0/26202368814744/37516293294994)
- [Asana task: Implement blueprint/command for "ember micro"](https://app.asana.com/0/26202368814744/37516293294991)
# Description

Handled similarly to the micro:component command

This PR implements the `ember micro:library` command which generates the files required for a micro-library.
- `mkdir some_folder`
- `cd some_folder`
- `npm init`
- `npm install --save-dev ember-micro-addon`
- `ember micro:library my-library`

We now have a folder `some_folder/my_library`, which contains the files `package.json`, `index.js` and `library.js`. This folded can be installed as an ember addon to a parent app. The parent app can then import the library via `import myLibrary from '${appName}/lib/my-library';` and use it.
