### PR TITLE
Implemented micro:helper command and blueprint

### DIFF
--- a/blueprints/micro-helper/files/helper.js
+++ b/blueprints/micro-helper/files/helper.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Handlebars.makeBoundHelper(function() {
+  return 'Overwrite helper.js to modify your helper';
+});

--- a/blueprints/micro-helper/files/index.js
+++ b/blueprints/micro-helper/files/index.js
@@ -1,0 +1,30 @@
+/* jshint node: true */
+'use strict';
+
+var path = require('path');
+var Funnel = require('broccoli-funnel');
+
+module.exports = {
+  name: '<%= helperName %>',
+
+  treeForApp: function() {
+    return this.buildTree(this.root, ['helper.js']);
+  },
+
+  buildTree: function(sourceTree, includedFiles) {
+    var addon = this;
+
+    return new Funnel(sourceTree, {
+      include: includedFiles,
+      getDestinationPath: function(relativePath) {
+        return addon.mapFile(relativePath);
+      }
+    });
+  },
+
+  mapFile: function(relativePath) {
+    if (relativePath === 'helper.js') {
+      return path.join('helpers', this.name + '.js');
+    }
+  }
+};

--- a/blueprints/micro-helper/files/package.json
+++ b/blueprints/micro-helper/files/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "<%= helperName %>",
+  "version": "0.0.0",
+  "description": "An ember-cli micro-component",
+  "repository": "",
+  "engines": {
+    "node": ">= 0.10.0"
+  },
+  "dependencies": {
+    "broccoli-funnel": "^0.2.3"
+  },
+  "keywords": [
+    "ember-addon",
+    "ember-micro-addon",
+    "ember-micro-component"
+  ]
+}

--- a/blueprints/micro-helper/index.js
+++ b/blueprints/micro-helper/index.js
@@ -1,0 +1,13 @@
+module.exports = {
+  description: 'The default blueprint for ember-cli micro-addon helper.',
+
+  locals: function(options) {
+    var helperEntity    = options.entity;
+    var helperName   = helperEntity.name;
+
+    return {
+      helperName: helperName,
+      emberCLIVersion: require('../../package').version,
+    };
+  },
+};

--- a/lib/commands/helper.js
+++ b/lib/commands/helper.js
@@ -1,0 +1,13 @@
+module.exports = {
+  name: 'micro:helper',
+  description: 'Creates files required for a micro-helper to work',
+  works: 'outsideProject',
+
+  validateAndRun: function(rawArgs) {
+    return this.run({}, rawArgs);
+  },
+
+  run: function(options, rawArgs) {
+    return require('../tasks/helper')(rawArgs, this.project);
+  }
+};

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   'micro:hello': require('./hello'),
   'micro:component': require('./component'),
-  'micro:library': require('./library')
+  'micro:library': require('./library'),
+  'micro:helper': require('./helper')
 };

--- a/lib/tasks/helper.js
+++ b/lib/tasks/helper.js
@@ -1,0 +1,19 @@
+/*jshint node:true*/
+'use strict';
+
+var Promise = require('../ext/promise');
+var runCommand = require('../utils/run-command');
+
+module.exports = function(rawArgs, project) {
+
+  var name = rawArgs[0];
+  if (name) {
+    var command = 'ember new ' + name + ' --blueprint ./node_modules/ember-micro-addon/blueprints/micro-helper --skip-npm --skip-bower --skip-git'
+    var msg = 'Creating micro-component in ./' + name
+    return runCommand(command, msg, {
+      cwd: project.root
+    })();
+  } else {
+    return Promise.reject(new Error('A "name" parameter is required to generate a micro-helper'));
+  }
+};


### PR DESCRIPTION
- [Asana task: ember micro helper](https://app.asana.com/0/26202368814744/37516293294996)
- [Asana task: Implement blueprint/command for "ember micro"](https://app.asana.com/0/26202368814744/37516293294991)
# Description

This PR implements the `ember micro:helper` command in the same fashion as `ember micro:component` and `ember micro:library`.
- `mkdir some_folder`
- `cd some_folder`
- `npm init`
- `npm install --save-dev ember-micro-addon`
- `ember micro:helper my_helper`

We now have a folder `some_folder/my-helper` containing files `package.json`, `index.js` and `helper.js`. This folder can be installed as an ember-addon and used by the parent app as any other handlebars helper.
