### PR TITLE
ember-micro CLI

### DIFF
--- a/lib/cli/component.js
+++ b/lib/cli/component.js
@@ -1,0 +1,8 @@
+#! /usr/bin/env node
+
+if (process.argv.length < 3) {
+  console.error("You must provide a name for the component");
+} else {
+  require('../tasks/component')([process.argv[2]], this.project)
+    .finally(process.exit);
+}

--- a/lib/cli/hello.js
+++ b/lib/cli/hello.js
@@ -1,0 +1,3 @@
+#! /usr/bin/env node
+
+console.log('Hello world');

--- a/lib/cli/helper.js
+++ b/lib/cli/helper.js
@@ -1,0 +1,8 @@
+#! /usr/bin/env node
+
+if (process.argv.length < 3) {
+  console.error("You must provide a name for the helper");
+} else {
+  require('../tasks/helper')([process.argv[2]], this.project)
+    .finally(process.exit);
+}

--- a/lib/cli/library.js
+++ b/lib/cli/library.js
@@ -1,0 +1,8 @@
+#! /usr/bin/env node
+
+if (process.argv.length < 3) {
+  console.error("You must provide a name for the library");
+} else {
+  require('../tasks/library')([process.argv[2]], this.project)
+    .finally(process.exit);
+}

--- a/lib/commands/component.js
+++ b/lib/commands/component.js
@@ -8,6 +8,6 @@ module.exports = {
   },
 
   run: function(options, rawArgs) {
-    return require('../tasks/component')(rawArgs, this.project);
+    return require('../tasks/component')(rawArgs);
   }
 };

--- a/lib/commands/helper.js
+++ b/lib/commands/helper.js
@@ -8,6 +8,6 @@ module.exports = {
   },
 
   run: function(options, rawArgs) {
-    return require('../tasks/helper')(rawArgs, this.project);
+    return require('../tasks/helper')(rawArgs);
   }
 };

--- a/lib/commands/library.js
+++ b/lib/commands/library.js
@@ -8,6 +8,6 @@ module.exports = {
   },
 
   run: function(options, rawArgs) {
-    return require('../tasks/library')(rawArgs, this.project);
+    return require('../tasks/library')(rawArgs);
   }
 };

--- a/lib/tasks/component.js
+++ b/lib/tasks/component.js
@@ -1,17 +1,22 @@
 /*jshint node:true*/
 'use strict';
 
+var path = require('path');
 var Promise = require('../ext/promise');
 var runCommand = require('../utils/run-command');
 
-module.exports = function(rawArgs, project) {
+module.exports = function(rawArgs) {
 
   var name = rawArgs[0];
   if (name) {
-    var command = 'ember new ' + name + ' --blueprint ./node_modules/ember-micro-addon/blueprints/micro-component --skip-npm --skip-bower --skip-git'
-    var msg = 'Creating micro-component in ./' + name
+
+    var blueprintName = "micro-component";
+    var blueprintFolderRelativePath = "../../blueprints";
+    var blueprintPath = path.resolve(__dirname, blueprintFolderRelativePath, blueprintName);
+    var command = 'ember new ' + name + ' --blueprint ' + blueprintPath + ' --skip-npm --skip-bower --skip-git';
+    var msg = 'Creating micro-component in ./' + name;
     return runCommand(command, msg, {
-      cwd: project.root
+      cwd: process.cwd()
     })();
   } else {
     return Promise.reject(new Error('A "name" parameter is required to generate a micro-component'));

--- a/lib/tasks/helper.js
+++ b/lib/tasks/helper.js
@@ -1,6 +1,7 @@
 /*jshint node:true*/
 'use strict';
 
+var path = require('path');
 var Promise = require('../ext/promise');
 var runCommand = require('../utils/run-command');
 
@@ -8,10 +9,13 @@ module.exports = function(rawArgs, project) {
 
   var name = rawArgs[0];
   if (name) {
-    var command = 'ember new ' + name + ' --blueprint ./node_modules/ember-micro-addon/blueprints/micro-helper --skip-npm --skip-bower --skip-git'
+    var blueprintName = "micro-helper";
+    var blueprintFolderRelativePath = "../../blueprints";
+    var blueprintPath = path.resolve(__dirname, blueprintFolderRelativePath, blueprintName);
+    var command = 'ember new ' + name + ' --blueprint ' + blueprintPath + ' --skip-npm --skip-bower --skip-git';
     var msg = 'Creating micro-component in ./' + name
     return runCommand(command, msg, {
-      cwd: project.root
+      cwd: process.cwd()
     })();
   } else {
     return Promise.reject(new Error('A "name" parameter is required to generate a micro-helper'));

--- a/lib/tasks/library.js
+++ b/lib/tasks/library.js
@@ -1,17 +1,21 @@
 /*jshint node:true*/
 'use strict';
 
+var path = require('path');
 var Promise = require('../ext/promise');
 var runCommand = require('../utils/run-command');
 
-module.exports = function(rawArgs, project) {
+module.exports = function(rawArgs) {
 
   var name = rawArgs[0];
   if (name) {
-    var command = 'ember new ' + name + ' --blueprint ./node_modules/ember-micro-addon/blueprints/micro-library --skip-npm --skip-bower --skip-git'
-    var msg = 'Creating micro-component in ./' + name
+    var blueprintName = "micro-library";
+    var blueprintFolderRelativePath = "../../blueprints";
+    var blueprintPath = path.resolve(__dirname, blueprintFolderRelativePath, blueprintName);
+    var command = 'ember new ' + name + ' --blueprint ' + blueprintPath + ' --skip-npm --skip-bower --skip-git';
+    var msg = 'Creating micro-library in ./' + name
     return runCommand(command, msg, {
-      cwd: project.root
+      cwd: process.cwd()
     })();
   } else {
     return Promise.reject(new Error('A "name" parameter is required to generate a micro-library'));

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "preferGlobal": "true",
   "bin": {
     "ember-micro:hello": "lib/cli/hello.js",
-    "ember-micro:component": "lib/cli/component.js"
+    "ember-micro:component": "lib/cli/component.js",
+    "ember-micro:library": "lib/cli/library.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "bin": {
     "ember-micro:hello": "lib/cli/hello.js",
     "ember-micro:component": "lib/cli/component.js",
-    "ember-micro:library": "lib/cli/library.js"
+    "ember-micro:library": "lib/cli/library.js",
+    "ember-micro:helper": "lib/cli/helper.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,5 +45,10 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"
+  },
+  "preferGlobal": "true",
+  "bin": {
+    "ember-micro:hello": "lib/cli/hello.js",
+    "ember-micro:component": "lib/cli/component.js"
   }
 }


### PR DESCRIPTION
- [Asana task: Look into relying on a regular npm package approach to expose ember micro as a global command](https://app.asana.com/0/26202368814744/37750065039931)
# Description

This PR makes use of the `bin` option of an `npm` package to expose global command line commands, transforming this addon into a globally installable CLI.

Since the global ember command is already taken up by ember-cli, the list of global commands this PR enables is
- `ember-micro:component component-name` - creates a flat-structured micro-component in the folder "component-name"
- `ember-micro:library library-name` - creates a flat-structured micro-library in the folder "library-name"
- `ember-micro:helper helper-name` - creates a flat-structured micro-helper in the folder "helper-name"
- `ember-micro:build addon-name` - converts the micro-addon (component, library or helper) in the folder "addon-name" into a properly structured ember-addon and puts int into the "addon-name/dist" folder.
# Usage
- Install the package globally - `npm install -g ember-micro-addon`
- The listed commands can now be used anywhere
# Limitations
- **The addon name needs to be provided in a dasherized form** - ember-cli handles dasherization automatically, so we might want to look into doing that as well
- **If no name is provided, an error is returned** - It's technically possible to make it so the addon is created in the current folder and named the current folder name in that case, but I'm not sure if that's what we want
- **If folder with specified name already exists, an error is returned** - An option would be to simply overwrite the folder, or at least prompt the user to overwrite it.
- **`ember-micro:x` is a lengthy command** - we could provide a shorthand alias, for instance, `em:x`
