### PR TITLE
Added missing build command, refactored stuff

### DIFF
--- a/lib/cli/build.js
+++ b/lib/cli/build.js
@@ -1,0 +1,5 @@
+#! /usr/bin/env node
+
+require('../commands/build').validateAndRun([process.argv[2]])
+  .catch(console.error)
+  .finally(process.exit);

--- a/lib/cli/component.js
+++ b/lib/cli/component.js
@@ -1,8 +1,5 @@
 #! /usr/bin/env node
 
-if (process.argv.length < 3) {
-  console.error("You must provide a name for the component");
-} else {
-  require('../tasks/component')([process.argv[2]], this.project)
-    .finally(process.exit);
-}
+require('../commands/component').validateAndRun([process.argv[2]])
+	.catch(console.error)
+	.finally(process.exit);

--- a/lib/cli/hello.js
+++ b/lib/cli/hello.js
@@ -1,3 +1,5 @@
 #! /usr/bin/env node
 
-console.log('Hello world');
+require('../commands/hello').validateAndRun([process.argv[2]])
+	.catch(console.error)
+	.finally(process.exit);

--- a/lib/cli/helper.js
+++ b/lib/cli/helper.js
@@ -1,8 +1,5 @@
 #! /usr/bin/env node
 
-if (process.argv.length < 3) {
-  console.error("You must provide a name for the helper");
-} else {
-  require('../tasks/helper')([process.argv[2]], this.project)
-    .finally(process.exit);
-}
+require('../commands/helper').validateAndRun([process.argv[2]])
+	.catch(console.error)
+	.finally(process.exit);

--- a/lib/cli/library.js
+++ b/lib/cli/library.js
@@ -1,8 +1,5 @@
 #! /usr/bin/env node
 
-if (process.argv.length < 3) {
-  console.error("You must provide a name for the library");
-} else {
-  require('../tasks/library')([process.argv[2]], this.project)
-    .finally(process.exit);
-}
+require('../commands/library').validateAndRun([process.argv[2]])
+  .catch(console.error)
+  .finally(process.exit);

--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -119,18 +119,16 @@ function buildMicroAddon(microAddon, type) {
 }
 
 module.exports = function(rawArgs) {
+  var name = rawArgs[0];
 
-  var microAddon = {
-    name: rawArgs[0],
-    path: path.join(process.cwd(), rawArgs[0])
-  };
+  if (name) {
+    var microAddon = { name: name, path: path.join(process.cwd(), name) };
 
-  if (microAddon.name) {
     return readFile(path.join(microAddon.path, 'package.json'))
-    .then(determineMicroAddonType)
-    .then(function(type) {
-      return buildMicroAddon(microAddon, type);
-  	});
+      .then(determineMicroAddonType)
+      .then(function(type) {
+        return buildMicroAddon(microAddon, type);
+    	});
 
   } else {
     return Promise.reject(new Error('A "name" parameter is required to build a micro-addon'));

--- a/lib/tasks/component.js
+++ b/lib/tasks/component.js
@@ -6,7 +6,6 @@ var Promise = require('../ext/promise');
 var runCommand = require('../utils/run-command');
 
 module.exports = function(rawArgs) {
-
   var name = rawArgs[0];
   if (name) {
 

--- a/lib/utils/run-command.js
+++ b/lib/utils/run-command.js
@@ -50,4 +50,5 @@ function commandError(command, err) {
   } else {
     ui.write(err);
   }
+  ui.write('\n');
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "ember-micro:hello": "lib/cli/hello.js",
     "ember-micro:component": "lib/cli/component.js",
     "ember-micro:library": "lib/cli/library.js",
-    "ember-micro:helper": "lib/cli/helper.js"
+    "ember-micro:helper": "lib/cli/helper.js",
+    "ember-micro:build": "lib/cli/build.js"
   }
 }


### PR DESCRIPTION
- [Asana task: Add missing build command](https://app.asana.com/0/26202368814744/37929511440824)
# Description

The `ember-micro:build addon-name` commit didn't get into #7, so it's being added through this PR.

I've also used the opportunity to refactor some things. Now, the CLI simply wraps the regular ember commands, so all code is completely reused and the CLI is simply a layer on top of the ember-addon.
