### PR TITLE
Added ember-micro:extract library command

### DIFF
--- a/lib/cli/extract.js
+++ b/lib/cli/extract.js
@@ -1,0 +1,5 @@
+#! /usr/bin/env node
+
+require('../commands/extract').validateAndRun([process.argv[2], process.argv[3]])
+  .catch(console.error)
+  .finally(process.exit);

--- a/lib/commands/extract.js
+++ b/lib/commands/extract.js
@@ -1,0 +1,44 @@
+var dasherize = require('../utils/string').dasherize;
+var Promise = require('../ext/promise');
+
+module.exports = {
+  name: 'micro:extract',
+  description: 'Extracts entities from an existing app into a micro-addon folder',
+  works: 'outsideProject',
+
+  validateAndRun: function(rawArgs) {
+    var options = {
+      type: rawArgs[0],
+      name: rawArgs[1]
+    }
+    return this.validateType(options).then(this.validateName).then(this.run);
+  },
+
+  validateType: function(options) {
+    return new Promise(function(resolve, reject) {
+      if (options.type) {
+        resolve(options);
+      } else {
+        reject('You must provide the type of the entity to extract');
+      }
+    })
+  },
+
+  validateName: function(options) {
+    return new Promise(function(resolve, reject) {
+      if (options.name) {
+        resolve(options);
+      } else {
+        reject('You must provide the name of the entity to extract');
+      }
+    })
+  },
+
+  run: function(options) {
+    if (options.type === 'library') {
+      return require('../tasks/extract-library')(dasherize(options.name));
+    } else {
+      return Promise.reject('Something went wrong.');
+    }
+  }
+};

--- a/lib/tasks/extract-library.js
+++ b/lib/tasks/extract-library.js
@@ -51,9 +51,9 @@ function insertAddonName(name) {
 }
 
 function overwriteLibraryJs(name) {
-  var oldHelper = path.join('app', 'lib', name + '.js');
-  var newHelper = path.join('addon', name, 'helper.js');
-  return copy(oldHelper, newHelper, { clobber: true }).then(function() {
+  var oldLibrary = path.join('app', 'lib', name + '.js');
+  var newLibrary = path.join('addon', name, 'library.js');
+  return copy(oldLibrary, newLibrary, { clobber: true }).then(function() {
     return Promise.resolve(name);
   });
 }

--- a/lib/tasks/extract-library.js
+++ b/lib/tasks/extract-library.js
@@ -1,0 +1,72 @@
+/*jshint node:true*/
+'use strict';
+
+var PLACEHOLDER = '<%= libraryName %>';
+
+var Promise = require('../ext/promise');
+var fs = require('fs-extra');
+var path = require('path');
+var ui = require('../ui');
+
+
+var ensureDir = Promise.denodeify(fs.ensureDir);
+var copy = Promise.denodeify(fs.copy);
+var readFile = Promise.denodeify(fs.readFile);
+var writeFile = Promise.denodeify(fs.writeFile);
+
+function createAddonFolder(name) {
+  return ensureDir(path.join('addon', name)).then(function() {
+    return Promise.resolve(name);
+  });
+}
+
+function copyBlueprintFiles(name) {
+  var blueprintName = "micro-library";
+  var blueprintFolderRelativePath = "../../blueprints";
+  var blueprintPath = path.resolve(__dirname, blueprintFolderRelativePath, blueprintName);
+
+  var srcPath = path.join(blueprintPath, 'files');
+  var destPath = path.join('addon', name);
+
+  return copy(srcPath, destPath).then(function() {
+    return Promise.resolve(name);
+  });
+}
+
+function replaceInFile(file, placeholder, value) {
+  return readFile(file, { encoding: 'utf-8' }).then(function(data) {
+    var data = data.replace(placeholder, value);
+    return writeFile(file, data);
+  });
+}
+
+function insertAddonName(name) {
+  var indexJsFile = path.join('addon', name, 'index.js');
+  var packageJsonFile = path.join('addon', name, 'package.json');
+  return replaceInFile(indexJsFile, PLACEHOLDER, name).then(function() {
+    return replaceInFile(packageJsonFile, PLACEHOLDER, name);
+  }).then(function() {
+    return Promise.resolve(name);
+  });
+}
+
+function overwriteLibraryJs(name) {
+  var oldHelper = path.join('app', 'lib', name + '.js');
+  var newHelper = path.join('addon', name, 'helper.js');
+  return copy(oldHelper, newHelper, { clobber: true }).then(function() {
+    return Promise.resolve(name);
+  });
+}
+
+module.exports = function(name) {
+  ui.start('Extracting library ' + name + ' into addon/' + name + '\n');
+
+  return createAddonFolder(name)
+  .then(copyBlueprintFiles)
+  .then(insertAddonName)
+  .then(overwriteLibraryJs)
+  .then(function() {
+    ui.write('Succesfully extracted library\n');
+    return Promise.resolve();
+  })
+};

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "ember-micro:component": "lib/cli/component.js",
     "ember-micro:library": "lib/cli/library.js",
     "ember-micro:helper": "lib/cli/helper.js",
-    "ember-micro:build": "lib/cli/build.js"
+    "ember-micro:build": "lib/cli/build.js",
+    "ember-micro:extract": "lib/cli/extract.js"
   }
 }


### PR DESCRIPTION
- [Asana task: ember-micro:extract library library-name](https://app.asana.com/0/26202368814744/37904326651652)
# Description

This PR extracts a library from an existing app into the folder it creates - `addon/library-name`. The extracted library has a flat, micro-addon structure.
# Implementation

Originally, I wanted to use the same `ember new` command I'm using in `ember-micro:library` to create a new library. Then, I would simply overwrite the library.js blueprint file with the one I'm extracting.

However, **`ember new` is not allowed to run inside an ember-cli project folder or any of it's subfolders** so that was not an option.

Instead, I use the `copy` function of the `fs-extra` node module, to copy the `blueprint/files` folder manually, then replace the placeholder strings within applicable files and finally overwrite the `library.js` file.
