### PR TITLE
Added support for helper extraction via "ember-micro:extract helper"

### DIFF
--- a/lib/commands/extract.js
+++ b/lib/commands/extract.js
@@ -10,7 +10,7 @@ module.exports = {
     var options = {
       type: rawArgs[0],
       name: rawArgs[1]
-    }
+    };
     return this.validateType(options).then(this.validateName).then(this.run);
   },
 
@@ -21,7 +21,7 @@ module.exports = {
       } else {
         reject('You must provide the type of the entity to extract');
       }
-    })
+    });
   },
 
   validateName: function(options) {
@@ -31,12 +31,14 @@ module.exports = {
       } else {
         reject('You must provide the name of the entity to extract');
       }
-    })
+    });
   },
 
   run: function(options) {
     if (options.type === 'library') {
       return require('../tasks/extract-library')(dasherize(options.name));
+    } else if (options.type === 'helper') {
+      return require('../tasks/extract-helper')(dasherize(options.name));
     } else {
       return Promise.reject('Something went wrong.');
     }

--- a/lib/tasks/component.js
+++ b/lib/tasks/component.js
@@ -2,7 +2,6 @@
 'use strict';
 
 var path = require('path');
-var Promise = require('../ext/promise');
 var runCommand = require('../utils/run-command');
 
 module.exports = function(options) {

--- a/lib/tasks/extract-helper.js
+++ b/lib/tasks/extract-helper.js
@@ -1,7 +1,7 @@
 /*jshint node:true*/
 'use strict';
 
-var PLACEHOLDER = '<%= libraryName %>';
+var PLACEHOLDER = '<%= helperName %>';
 
 var Promise = require('../ext/promise');
 var fs = require('fs-extra');
@@ -21,7 +21,7 @@ function createAddonFolder(name) {
 }
 
 function copyBlueprintFiles(name) {
-  var blueprintName = "micro-library";
+  var blueprintName = "micro-helper";
   var blueprintFolderRelativePath = "../../blueprints";
   var blueprintPath = path.resolve(__dirname, blueprintFolderRelativePath, blueprintName);
 
@@ -50,23 +50,23 @@ function insertAddonName(name) {
   });
 }
 
-function overwriteLibraryJs(name) {
-  var oldLibrary = path.join('app', 'lib', name + '.js');
-  var newLibrary = path.join('addon', name, 'library.js');
-  return copy(oldLibrary, newLibrary, { clobber: true }).then(function() {
+function overwriteHelperJs(name) {
+  var oldPath = path.join('app', 'helpers', name + '.js');
+  var newPath = path.join('addon', name, 'helper.js');
+  return copy(oldPath, newPath, { clobber: true }).then(function() {
     return Promise.resolve(name);
   });
 }
 
 module.exports = function(name) {
-  ui.start('Extracting library ' + name + ' into addon/' + name + '\n');
+  ui.start('Extracting helper ' + name + ' into addon/' + name + '\n');
 
   return createAddonFolder(name)
   .then(copyBlueprintFiles)
   .then(insertAddonName)
-  .then(overwriteLibraryJs)
+  .then(overwriteHelperJs)
   .then(function() {
-    ui.write('Succesfully extracted library\n');
+    ui.write('Succesfully extracted helper\n');
     return Promise.resolve();
   });
 };

--- a/lib/tasks/helper.js
+++ b/lib/tasks/helper.js
@@ -2,7 +2,6 @@
 'use strict';
 
 var path = require('path');
-var Promise = require('../ext/promise');
 var runCommand = require('../utils/run-command');
 
 module.exports = function(options) {

--- a/lib/tasks/library.js
+++ b/lib/tasks/library.js
@@ -2,7 +2,6 @@
 'use strict';
 
 var path = require('path');
-var Promise = require('../ext/promise');
 var runCommand = require('../utils/run-command');
 
 module.exports = function(options) {


### PR DESCRIPTION
- [Asana task: ember-micro:extract helper helper-name](https://app.asana.com/0/26202368814744/37904326651650)
# Description

This PR adds support for helper extraction to the `ember-micro:extract` command.

Calling `ember-micro:extract helper helper-name` or `ember-micro:extract helper helperName` will do the following:
- create the folder `addon/helper-name` within the ember app folder
- create `addon/helper-name/index.js` file inside the newly created folder, required to make the extracted addon work as an ember micro addon
- create `addon/helper-name/package.json` inside the created folder
- copy/rename `app/helpers/helper-name.js` to `addon/helper-name/helper.js`
