### PR TITLE
Added support for component extraction to "ember-micro:extract" command

### DIFF
--- a/lib/commands/extract.js
+++ b/lib/commands/extract.js
@@ -39,6 +39,8 @@ module.exports = {
       return require('../tasks/extract-library')(dasherize(options.name));
     } else if (options.type === 'helper') {
       return require('../tasks/extract-helper')(dasherize(options.name));
+    } else if (options.type === 'component') {
+      return require('../tasks/extract-component')(dasherize(options.name));
     } else {
       return Promise.reject('Something went wrong.');
     }

--- a/lib/tasks/extract-component.js
+++ b/lib/tasks/extract-component.js
@@ -1,0 +1,98 @@
+/*jshint node:true*/
+'use strict';
+
+var PLACEHOLDER = '<%= componentName %>';
+
+var Promise = require('../ext/promise');
+var fs = require('fs-extra');
+var path = require('path');
+var ui = require('../ui');
+
+
+var ensureDir = Promise.denodeify(fs.ensureDir);
+var copy = Promise.denodeify(fs.copy);
+var readFile = Promise.denodeify(fs.readFile);
+var writeFile = Promise.denodeify(fs.writeFile);
+
+function createAddonFolder(name) {
+  return ensureDir(path.join('addon', name)).then(function() {
+    return Promise.resolve(name);
+  });
+}
+
+function copyBlueprintFiles(name) {
+  var blueprintName = "micro-component";
+  var blueprintFolderRelativePath = "../../blueprints";
+  var blueprintPath = path.resolve(__dirname, blueprintFolderRelativePath, blueprintName);
+
+  var srcPath = path.join(blueprintPath, 'files');
+  var destPath = path.join('addon', name);
+
+  return copy(srcPath, destPath).then(function() {
+    return Promise.resolve(name);
+  });
+}
+
+function replaceInFile(file, placeholder, value) {
+  return readFile(file, { encoding: 'utf-8' }).then(function(data) {
+    var modifiedData = data.replace(placeholder, value);
+    return writeFile(file, modifiedData);
+  });
+}
+
+function insertAddonName(name) {
+  var indexJsFile = path.join('addon', name, 'index.js');
+  var packageJsonFile = path.join('addon', name, 'package.json');
+  var styleCssFile = path.join('addon', name, 'style.css');
+  return replaceInFile(indexJsFile, PLACEHOLDER, name).then(function() {
+    return replaceInFile(packageJsonFile, PLACEHOLDER, name);
+  }).then(function() {
+    return replaceInFile(styleCssFile, PLACEHOLDER, name);
+  }).then(function() {
+    return Promise.resolve(name);
+  });
+}
+
+function copyFileIfExists(oldFile, newFile) {
+  return new Promise(function(resolve) {
+    copy(oldFile, newFile, { clobber: true }).finally(resolve);
+  });
+}
+
+function overwriteComponentJs(name) {
+  var oldFile = path.join('app', 'components', name + '.js');
+  var newFile = path.join('addon', name, 'component.js');
+  return copyFileIfExists(oldFile, newFile).then(function() {
+    return Promise.resolve(name);
+  });
+}
+
+function overwriteTemplateHbs(name) {
+  var oldFile = path.join('app', 'templates/components', name + '.hbs');
+  var newFile = path.join('addon', name, 'template.hbs');
+  return copyFileIfExists(oldFile, newFile).then(function() {
+    return Promise.resolve(name);
+  });
+}
+
+function overwriteTemplateHbs(name) {
+  var oldFile = path.join('app', 'styles', name + '.css');
+  var newFile = path.join('addon', name, 'style.css');
+  return copyFileIfExists(oldFile, newFile).then(function() {
+    return Promise.resolve(name);
+  });
+}
+
+module.exports = function(name) {
+  ui.start('Extracting component ' + name + ' into addon/' + name + '\n');
+
+  return createAddonFolder(name)
+  .then(copyBlueprintFiles)
+  .then(insertAddonName)
+  .then(overwriteComponentJs)
+  .then(overwriteTemplateHbs)
+  .then(function() {
+    ui.write('Succesfully extracted component\n');
+    return Promise.resolve();
+  });
+};


### PR DESCRIPTION
- [Asana task: ember-micro:extract component component-name](https://app.asana.com/0/26202368814744/37904326651648)
# Description

This PR adds support for component extraction from an existing app.

Running `ember-micro:extract component component-name` from within an ember-app folder will do the following:
- Create a subfolder `addon/component-name`
- Create `addon/component-name/index.js` with the required code to make it an ember-micro-addon
- Create `addon/component-name/package.json`
- Copy `app/components/component-name.js` to `addon/component-name/component.js`
- Copy `app/templates/components/component-name.hbs` to `addon/component-name/template.hbs`
- Copy `app/styles/component-name.css` to `addon/component-name/style.css`

If any of these files do not exist, default files will be created.
