### PR TITLE
Refactor extract command

### DIFF
--- a/lib/tasks/extract-component.js
+++ b/lib/tasks/extract-component.js
@@ -20,8 +20,7 @@ function createAddonFolder(name) {
   });
 }
 
-function copyBlueprintFiles(name) {
-  var blueprintName = "micro-component";
+function copyBlueprintFiles(name, blueprintName) {
   var blueprintFolderRelativePath = "../../blueprints";
   var blueprintPath = path.resolve(__dirname, blueprintFolderRelativePath, blueprintName);
 
@@ -40,15 +39,20 @@ function replaceInFile(file, placeholder, value) {
   });
 }
 
-function insertAddonName(name) {
+function replaceInFiles(files, placeholder, value) {
+  return Promise.map(files, function(file) {
+    return replaceInFile(file, placeholder, value);
+  });
+}
+
+function insertAddonName(placeholder, name) {
   var indexJsFile = path.join('addon', name, 'index.js');
   var packageJsonFile = path.join('addon', name, 'package.json');
   var styleCssFile = path.join('addon', name, 'style.css');
-  return replaceInFile(indexJsFile, PLACEHOLDER, name).then(function() {
-    return replaceInFile(packageJsonFile, PLACEHOLDER, name);
-  }).then(function() {
-    return replaceInFile(styleCssFile, PLACEHOLDER, name);
-  }).then(function() {
+
+  var files = [indexJsFile, packageJsonFile, styleCssFile];
+
+  return replaceInFiles(files, placeholder, name).then(function() {
     return Promise.resolve(name);
   });
 }
@@ -86,9 +90,11 @@ function overwriteTemplateHbs(name) {
 module.exports = function(name) {
   ui.start('Extracting component ' + name + ' into addon/' + name + '\n');
 
-  return createAddonFolder(name)
-  .then(copyBlueprintFiles)
-  .then(insertAddonName)
+  return createAddonFolder(name).then(function() {
+    return copyBlueprintFiles(name, 'micro-component');
+  }).then(function() {
+    return insertAddonName(PLACEHOLDER, name);
+  })
   .then(overwriteComponentJs)
   .then(overwriteTemplateHbs)
   .then(function() {

--- a/lib/tasks/extract-component.js
+++ b/lib/tasks/extract-component.js
@@ -15,9 +15,7 @@ var readFile = Promise.denodeify(fs.readFile);
 var writeFile = Promise.denodeify(fs.writeFile);
 
 function createAddonFolder(name) {
-  return ensureDir(path.join('addon', name)).then(function() {
-    return Promise.resolve(name);
-  });
+  return ensureDir(path.join('addon', name));
 }
 
 function copyBlueprintFiles(name, blueprintName) {
@@ -27,9 +25,7 @@ function copyBlueprintFiles(name, blueprintName) {
   var srcPath = path.join(blueprintPath, 'files');
   var destPath = path.join('addon', name);
 
-  return copy(srcPath, destPath).then(function() {
-    return Promise.resolve(name);
-  });
+  return copy(srcPath, destPath);
 }
 
 function replaceInFile(file, placeholder, value) {
@@ -63,27 +59,24 @@ function copyFileIfExists(oldFile, newFile) {
   });
 }
 
-function overwriteComponentJs(name) {
-  var oldFile = path.join('app', 'components', name + '.js');
-  var newFile = path.join('addon', name, 'component.js');
-  return copyFileIfExists(oldFile, newFile).then(function() {
-    return Promise.resolve(name);
-  });
-}
+function overwriteFiles(name) {
+  var fileMappings = [
+    {
+      oldPath: path.join('app', 'components', name + '.js'),
+      newPath: path.join('addon', name, 'component.js')
+    },
+    {
+      oldPath: path.join('app', 'templates/components', name + '.hbs'),
+      newPath: path.join('addon', name, 'template.hbs')
+    },
+    {
+      oldPath: path.join('app', 'styles', name + '.css'),
+      newPath: path.join('addon', name, 'style.css')
+    }
+  ];
 
-function overwriteTemplateHbs(name) {
-  var oldFile = path.join('app', 'templates/components', name + '.hbs');
-  var newFile = path.join('addon', name, 'template.hbs');
-  return copyFileIfExists(oldFile, newFile).then(function() {
-    return Promise.resolve(name);
-  });
-}
-
-function overwriteTemplateHbs(name) {
-  var oldFile = path.join('app', 'styles', name + '.css');
-  var newFile = path.join('addon', name, 'style.css');
-  return copyFileIfExists(oldFile, newFile).then(function() {
-    return Promise.resolve(name);
+  return Promise.map(fileMappings, function(fileMapping) {
+    return copyFileIfExists(fileMapping.oldPath, fileMapping.newPath);
   });
 }
 
@@ -94,10 +87,9 @@ module.exports = function(name) {
     return copyBlueprintFiles(name, 'micro-component');
   }).then(function() {
     return insertAddonName(PLACEHOLDER, name);
-  })
-  .then(overwriteComponentJs)
-  .then(overwriteTemplateHbs)
-  .then(function() {
+  }).then(function () {
+    return overwriteFiles(name);
+  }).then(function() {
     ui.write('Succesfully extracted component\n');
     return Promise.resolve();
   });

--- a/lib/tasks/extract-component.js
+++ b/lib/tasks/extract-component.js
@@ -1,66 +1,21 @@
 /*jshint node:true*/
 'use strict';
 
-var PLACEHOLDER = '<%= componentName %>';
-
-var Promise = require('../ext/promise');
-var fs = require('fs-extra');
 var path = require('path');
+var Promise = require('../ext/promise');
 var ui = require('../ui');
+var extractAddon = require('../utils/extract-addon');
 
-
-var ensureDir = Promise.denodeify(fs.ensureDir);
-var copy = Promise.denodeify(fs.copy);
-var readFile = Promise.denodeify(fs.readFile);
-var writeFile = Promise.denodeify(fs.writeFile);
-
-function createAddonFolder(name) {
-  return ensureDir(path.join('addon', name));
+function getFilesWithPlaceholdersFromName(name) {
+  return [
+    path.join('addon', name, 'index.js'),
+    path.join('addon', name, 'package.json'),
+    path.join('addon', name, 'style.css')
+  ];
 }
 
-function copyBlueprintFiles(name, blueprintName) {
-  var blueprintFolderRelativePath = "../../blueprints";
-  var blueprintPath = path.resolve(__dirname, blueprintFolderRelativePath, blueprintName);
-
-  var srcPath = path.join(blueprintPath, 'files');
-  var destPath = path.join('addon', name);
-
-  return copy(srcPath, destPath);
-}
-
-function replaceInFile(file, placeholder, value) {
-  return readFile(file, { encoding: 'utf-8' }).then(function(data) {
-    var modifiedData = data.replace(placeholder, value);
-    return writeFile(file, modifiedData);
-  });
-}
-
-function replaceInFiles(files, placeholder, value) {
-  return Promise.map(files, function(file) {
-    return replaceInFile(file, placeholder, value);
-  });
-}
-
-function insertAddonName(placeholder, name) {
-  var indexJsFile = path.join('addon', name, 'index.js');
-  var packageJsonFile = path.join('addon', name, 'package.json');
-  var styleCssFile = path.join('addon', name, 'style.css');
-
-  var files = [indexJsFile, packageJsonFile, styleCssFile];
-
-  return replaceInFiles(files, placeholder, name).then(function() {
-    return Promise.resolve(name);
-  });
-}
-
-function copyFileIfExists(oldFile, newFile) {
-  return new Promise(function(resolve) {
-    copy(oldFile, newFile, { clobber: true }).finally(resolve);
-  });
-}
-
-function overwriteFiles(name) {
-  var fileMappings = [
+function getFileMappingsFromName(name) {
+  return [
     {
       oldPath: path.join('app', 'components', name + '.js'),
       newPath: path.join('addon', name, 'component.js')
@@ -74,22 +29,20 @@ function overwriteFiles(name) {
       newPath: path.join('addon', name, 'style.css')
     }
   ];
-
-  return Promise.map(fileMappings, function(fileMapping) {
-    return copyFileIfExists(fileMapping.oldPath, fileMapping.newPath);
-  });
 }
 
 module.exports = function(name) {
   ui.start('Extracting component ' + name + ' into addon/' + name + '\n');
 
-  return createAddonFolder(name).then(function() {
-    return copyBlueprintFiles(name, 'micro-component');
-  }).then(function() {
-    return insertAddonName(PLACEHOLDER, name);
-  }).then(function () {
-    return overwriteFiles(name);
-  }).then(function() {
+  var options = {
+    addonName: name,
+    blueprintName: 'micro-component',
+    placeholder: '<%= componentName %>',
+    filesToReplacePlaceholderIn: getFilesWithPlaceholdersFromName(name),
+    fileMappings: getFileMappingsFromName(name)
+  }
+
+  return extractAddon(options).then(function() {
     ui.write('Succesfully extracted component\n');
     return Promise.resolve();
   });

--- a/lib/tasks/extract-helper.js
+++ b/lib/tasks/extract-helper.js
@@ -1,71 +1,39 @@
 /*jshint node:true*/
 'use strict';
 
-var PLACEHOLDER = '<%= helperName %>';
-
 var Promise = require('../ext/promise');
-var fs = require('fs-extra');
 var path = require('path');
 var ui = require('../ui');
+var extractAddon = require('../utils/extract-addon');
 
-
-var ensureDir = Promise.denodeify(fs.ensureDir);
-var copy = Promise.denodeify(fs.copy);
-var readFile = Promise.denodeify(fs.readFile);
-var writeFile = Promise.denodeify(fs.writeFile);
-
-function createAddonFolder(name) {
-  return ensureDir(path.join('addon', name)).then(function() {
-    return Promise.resolve(name);
-  });
+function getFilesWithPlaceholdersFromName(name) {
+  return [
+    path.join('addon', name, 'index.js'),
+    path.join('addon', name, 'package.json'),
+  ];
 }
 
-function copyBlueprintFiles(name) {
-  var blueprintName = "micro-helper";
-  var blueprintFolderRelativePath = "../../blueprints";
-  var blueprintPath = path.resolve(__dirname, blueprintFolderRelativePath, blueprintName);
-
-  var srcPath = path.join(blueprintPath, 'files');
-  var destPath = path.join('addon', name);
-
-  return copy(srcPath, destPath).then(function() {
-    return Promise.resolve(name);
-  });
-}
-
-function replaceInFile(file, placeholder, value) {
-  return readFile(file, { encoding: 'utf-8' }).then(function(data) {
-    var modifiedData = data.replace(placeholder, value);
-    return writeFile(file, modifiedData);
-  });
-}
-
-function insertAddonName(name) {
-  var indexJsFile = path.join('addon', name, 'index.js');
-  var packageJsonFile = path.join('addon', name, 'package.json');
-  return replaceInFile(indexJsFile, PLACEHOLDER, name).then(function() {
-    return replaceInFile(packageJsonFile, PLACEHOLDER, name);
-  }).then(function() {
-    return Promise.resolve(name);
-  });
-}
-
-function overwriteHelperJs(name) {
-  var oldPath = path.join('app', 'helpers', name + '.js');
-  var newPath = path.join('addon', name, 'helper.js');
-  return copy(oldPath, newPath, { clobber: true }).then(function() {
-    return Promise.resolve(name);
-  });
+function getFileMappingsFromName(name) {
+  return [
+    {
+      oldPath: path.join('app', 'helpers', name + '.js'),
+      newPath: path.join('addon', name, 'helper.js')
+    }
+  ];
 }
 
 module.exports = function(name) {
   ui.start('Extracting helper ' + name + ' into addon/' + name + '\n');
 
-  return createAddonFolder(name)
-  .then(copyBlueprintFiles)
-  .then(insertAddonName)
-  .then(overwriteHelperJs)
-  .then(function() {
+  var options = {
+    addonName: name,
+    blueprintName: 'micro-helper',
+    placeholder: '<%= helperName %>',
+    filesToReplacePlaceholderIn: getFilesWithPlaceholdersFromName(name),
+    fileMappings: getFileMappingsFromName(name)
+  }
+
+  return extractAddon(options).then(function() {
     ui.write('Succesfully extracted helper\n');
     return Promise.resolve();
   });

--- a/lib/tasks/extract-library.js
+++ b/lib/tasks/extract-library.js
@@ -1,71 +1,39 @@
 /*jshint node:true*/
 'use strict';
 
-var PLACEHOLDER = '<%= libraryName %>';
-
 var Promise = require('../ext/promise');
-var fs = require('fs-extra');
 var path = require('path');
 var ui = require('../ui');
+var extractAddon = require('../utils/extract-addon');
 
-
-var ensureDir = Promise.denodeify(fs.ensureDir);
-var copy = Promise.denodeify(fs.copy);
-var readFile = Promise.denodeify(fs.readFile);
-var writeFile = Promise.denodeify(fs.writeFile);
-
-function createAddonFolder(name) {
-  return ensureDir(path.join('addon', name)).then(function() {
-    return Promise.resolve(name);
-  });
+function getFilesWithPlaceholdersFromName(name) {
+  return [
+    path.join('addon', name, 'index.js'),
+    path.join('addon', name, 'package.json'),
+  ];
 }
 
-function copyBlueprintFiles(name) {
-  var blueprintName = "micro-library";
-  var blueprintFolderRelativePath = "../../blueprints";
-  var blueprintPath = path.resolve(__dirname, blueprintFolderRelativePath, blueprintName);
-
-  var srcPath = path.join(blueprintPath, 'files');
-  var destPath = path.join('addon', name);
-
-  return copy(srcPath, destPath).then(function() {
-    return Promise.resolve(name);
-  });
-}
-
-function replaceInFile(file, placeholder, value) {
-  return readFile(file, { encoding: 'utf-8' }).then(function(data) {
-    var modifiedData = data.replace(placeholder, value);
-    return writeFile(file, modifiedData);
-  });
-}
-
-function insertAddonName(name) {
-  var indexJsFile = path.join('addon', name, 'index.js');
-  var packageJsonFile = path.join('addon', name, 'package.json');
-  return replaceInFile(indexJsFile, PLACEHOLDER, name).then(function() {
-    return replaceInFile(packageJsonFile, PLACEHOLDER, name);
-  }).then(function() {
-    return Promise.resolve(name);
-  });
-}
-
-function overwriteLibraryJs(name) {
-  var oldLibrary = path.join('app', 'lib', name + '.js');
-  var newLibrary = path.join('addon', name, 'library.js');
-  return copy(oldLibrary, newLibrary, { clobber: true }).then(function() {
-    return Promise.resolve(name);
-  });
+function getFileMappingsFromName(name) {
+  return [
+    {
+      oldPath: path.join('app', 'lib', name + '.js'),
+      newPath: path.join('addon', name, 'library.js')
+    }
+  ];
 }
 
 module.exports = function(name) {
   ui.start('Extracting library ' + name + ' into addon/' + name + '\n');
 
-  return createAddonFolder(name)
-  .then(copyBlueprintFiles)
-  .then(insertAddonName)
-  .then(overwriteLibraryJs)
-  .then(function() {
+  var options = {
+    addonName: name,
+    blueprintName: 'micro-library',
+    placeholder: '<%= libraryName %>',
+    filesToReplacePlaceholderIn: getFilesWithPlaceholdersFromName(name),
+    fileMappings: getFileMappingsFromName(name)
+  }
+
+  return extractAddon(options).then(function() {
     ui.write('Succesfully extracted library\n');
     return Promise.resolve();
   });

--- a/lib/utils/extract-addon.js
+++ b/lib/utils/extract-addon.js
@@ -1,0 +1,57 @@
+var Promise = require('../ext/promise');
+var fs = require('fs-extra');
+var path = require('path');
+
+var ensureDir = Promise.denodeify(fs.ensureDir);
+var copy = Promise.denodeify(fs.copy);
+var readFile = Promise.denodeify(fs.readFile);
+var writeFile = Promise.denodeify(fs.writeFile);
+
+function createAddonFolder(name) {
+  return ensureDir(path.join('addon', name));
+}
+
+function copyBlueprintFiles(name, blueprintName) {
+  var blueprintFolderRelativePath = "../../blueprints";
+  var blueprintPath = path.resolve(__dirname, blueprintFolderRelativePath, blueprintName);
+
+  var srcPath = path.join(blueprintPath, 'files');
+  var destPath = path.join('addon', name);
+
+  return copy(srcPath, destPath);
+}
+
+function replaceInFile(file, placeholder, value) {
+  return readFile(file, { encoding: 'utf-8' }).then(function(data) {
+    var modifiedData = data.replace(placeholder, value);
+    return writeFile(file, modifiedData);
+  });
+}
+
+function replaceInFiles(files, placeholder, value) {
+  return Promise.map(files, function(file) {
+    return replaceInFile(file, placeholder, value);
+  });
+}
+
+function copyFileIfExists(oldFile, newFile) {
+  return new Promise(function(resolve) {
+    copy(oldFile, newFile, { clobber: true }).finally(resolve);
+  });
+}
+
+function overwriteFiles(fileMappings) {
+  return Promise.map(fileMappings, function(fileMapping) {
+    return copyFileIfExists(fileMapping.oldPath, fileMapping.newPath);
+  });
+}
+
+module.exports = function(options) {
+  return createAddonFolder(options.addonName).then(function() {
+    return copyBlueprintFiles(options.addonName, options.blueprintName);
+  }).then(function() {
+    return replaceInFiles(options.filesToReplacePlaceholderIn, options.placeholder, options.addonName);
+  }).then(function () {
+    return overwriteFiles(options.fileMappings);
+  })
+}

--- a/lib/utils/extract-addon.js
+++ b/lib/utils/extract-addon.js
@@ -1,6 +1,8 @@
-var Promise = require('../ext/promise');
 var fs = require('fs-extra');
 var path = require('path');
+
+var Promise = require('../ext/promise');
+var overwriteFiles = require('./overwriteFiles');
 
 var ensureDir = Promise.denodeify(fs.ensureDir);
 var copy = Promise.denodeify(fs.copy);
@@ -31,18 +33,6 @@ function replaceInFile(file, placeholder, value) {
 function replaceInFiles(files, placeholder, value) {
   return Promise.map(files, function(file) {
     return replaceInFile(file, placeholder, value);
-  });
-}
-
-function copyFileIfExists(oldFile, newFile) {
-  return new Promise(function(resolve) {
-    copy(oldFile, newFile, { clobber: true }).finally(resolve);
-  });
-}
-
-function overwriteFiles(fileMappings) {
-  return Promise.map(fileMappings, function(fileMapping) {
-    return copyFileIfExists(fileMapping.oldPath, fileMapping.newPath);
   });
 }
 

--- a/lib/utils/overwrite-files.js
+++ b/lib/utils/overwrite-files.js
@@ -1,0 +1,11 @@
+function copyFileIfExists(oldFile, newFile) {
+  return new Promise(function(resolve) {
+    copy(oldFile, newFile, { clobber: true }).finally(resolve);
+  });
+}
+
+module.exports = function(fileMappings) {
+  return Promise.map(fileMappings, function(fileMapping) {
+    return copyFileIfExists(fileMapping.oldPath, fileMapping.newPath);
+  });
+}


### PR DESCRIPTION
- [Asana task: Refactor extract command to get rid of duplicate code](https://app.asana.com/0/26202368814744/38174604906014)
# Description

This PR refactors the `extract-x` set of tasks (`extract-library`, `extract-helper`, `extract-component`). It generalizes the extraction logic and moves the common code into a separate module. 

It further breaks down the separate module by extracting file overwriting code into another module.

This should also allow us to at some point refactor the `build` command in a similar way.
