### PR TITLE
Remove pleasant progress module

### DIFF
--- a/lib/cli/build.js
+++ b/lib/cli/build.js
@@ -1,5 +1,7 @@
 #! /usr/bin/env node
 
+var ui = require('../ui');
+
 require('../commands/build').validateAndRun([process.argv[2]])
-  .catch(console.error)
+  .catch(ui.error)
   .finally(process.exit);

--- a/lib/cli/component.js
+++ b/lib/cli/component.js
@@ -1,5 +1,7 @@
 #! /usr/bin/env node
 
+var ui = require('../ui');
+
 require('../commands/component').validateAndRun([process.argv[2]])
-  .catch(console.error)
+  .catch(ui.error)
   .finally(process.exit);

--- a/lib/cli/extract.js
+++ b/lib/cli/extract.js
@@ -1,5 +1,7 @@
 #! /usr/bin/env node
 
+var ui = require('../ui');
+
 require('../commands/extract').validateAndRun([process.argv[2], process.argv[3]])
-  .catch(console.error)
+  .catch(ui.error)
   .finally(process.exit);

--- a/lib/cli/helper.js
+++ b/lib/cli/helper.js
@@ -1,5 +1,7 @@
 #! /usr/bin/env node
 
+var ui = require('../ui');
+
 require('../commands/helper').validateAndRun([process.argv[2]])
-	.catch(console.error)
+	.catch(ui.error)
 	.finally(process.exit);

--- a/lib/cli/library.js
+++ b/lib/cli/library.js
@@ -1,5 +1,7 @@
 #! /usr/bin/env node
 
+var ui = require('../ui');
+
 require('../commands/library').validateAndRun([process.argv[2]])
-  .catch(console.error)
+  .catch(ui.error)
   .finally(process.exit);

--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -1,9 +1,12 @@
 /*jshint node:true*/
 'use strict';
 
-var Promise = require('../ext/promise');
 var fs = require('fs-extra');
 var path = require('path');
+
+var ui = require('../ui');
+var Promise = require('../ext/promise');
+
 var copy = Promise.denodeify(fs.copy);
 var readFile = Promise.denodeify(fs.readFile);
 
@@ -86,21 +89,21 @@ function copyComponentStyle(microAddon) {
 }
 
 function buildMicroHelper(microAddon) {
-  console.log('Packaging helper...', microAddon.name);
+  ui.write('Packaging helper...', microAddon.name);
   return copyPackageJson(microAddon)
     .then(writeIndexJs)
     .then(copyHelperJs);
 }
 
 function buildMicroLibrary(microAddon) {
-  console.log('Packaging library...', microAddon.name);
+  ui.write('Packaging library...', microAddon.name);
   return copyPackageJson(microAddon)
     .then(writeIndexJs)
     .then(copyLibraryJs);
 }
 
 function buildMicroComponent(microAddon) {
-  console.log('Packaging component...', microAddon.name);
+  ui.write('Packaging component...', microAddon.name);
   return copyPackageJson(microAddon)
     .then(writeIndexJs)
     .then(copyComponentJs)

--- a/lib/tasks/extract-component.js
+++ b/lib/tasks/extract-component.js
@@ -32,7 +32,7 @@ function getFileMappingsFromName(name) {
 }
 
 module.exports = function(name) {
-  ui.start('Extracting component ' + name + ' into addon/' + name + '\n');
+  ui.write('Extracting component ' + name + ' into addon/' + name + '\n');
 
   var options = {
     addonName: name,

--- a/lib/tasks/extract-component.js
+++ b/lib/tasks/extract-component.js
@@ -32,7 +32,7 @@ function getFileMappingsFromName(name) {
 }
 
 module.exports = function(name) {
-  ui.write('Extracting component ' + name + ' into addon/' + name + '\n');
+  ui.write('Extracting component ' + name + ' into addon/' + name);
 
   var options = {
     addonName: name,
@@ -40,10 +40,10 @@ module.exports = function(name) {
     placeholder: '<%= componentName %>',
     filesToReplacePlaceholderIn: getFilesWithPlaceholdersFromName(name),
     fileMappings: getFileMappingsFromName(name)
-  }
+  };
 
   return extractAddon(options).then(function() {
-    ui.write('Succesfully extracted component\n');
+    ui.write('Succesfully extracted component');
     return Promise.resolve();
   });
 };

--- a/lib/tasks/extract-helper.js
+++ b/lib/tasks/extract-helper.js
@@ -23,7 +23,7 @@ function getFileMappingsFromName(name) {
 }
 
 module.exports = function(name) {
-  ui.write('Extracting helper ' + name + ' into addon/' + name + '\n');
+  ui.write('Extracting helper ' + name + ' into addon/' + name);
 
   var options = {
     addonName: name,
@@ -31,10 +31,10 @@ module.exports = function(name) {
     placeholder: '<%= helperName %>',
     filesToReplacePlaceholderIn: getFilesWithPlaceholdersFromName(name),
     fileMappings: getFileMappingsFromName(name)
-  }
+  };
 
   return extractAddon(options).then(function() {
-    ui.write('Succesfully extracted helper\n');
+    ui.write('Succesfully extracted helper');
     return Promise.resolve();
   });
 };

--- a/lib/tasks/extract-helper.js
+++ b/lib/tasks/extract-helper.js
@@ -23,7 +23,7 @@ function getFileMappingsFromName(name) {
 }
 
 module.exports = function(name) {
-  ui.start('Extracting helper ' + name + ' into addon/' + name + '\n');
+  ui.write('Extracting helper ' + name + ' into addon/' + name + '\n');
 
   var options = {
     addonName: name,

--- a/lib/tasks/extract-library.js
+++ b/lib/tasks/extract-library.js
@@ -23,7 +23,7 @@ function getFileMappingsFromName(name) {
 }
 
 module.exports = function(name) {
-  ui.start('Extracting library ' + name + ' into addon/' + name + '\n');
+  ui.write('Extracting library ' + name + ' into addon/' + name + '\n');
 
   var options = {
     addonName: name,
@@ -31,7 +31,7 @@ module.exports = function(name) {
     placeholder: '<%= libraryName %>',
     filesToReplacePlaceholderIn: getFilesWithPlaceholdersFromName(name),
     fileMappings: getFileMappingsFromName(name)
-  }
+  };
 
   return extractAddon(options).then(function() {
     ui.write('Succesfully extracted library\n');

--- a/lib/tasks/extract-library.js
+++ b/lib/tasks/extract-library.js
@@ -23,7 +23,7 @@ function getFileMappingsFromName(name) {
 }
 
 module.exports = function(name) {
-  ui.write('Extracting library ' + name + ' into addon/' + name + '\n');
+  ui.write('Extracting library ' + name + ' into addon/' + name);
 
   var options = {
     addonName: name,
@@ -34,7 +34,7 @@ module.exports = function(name) {
   };
 
   return extractAddon(options).then(function() {
-    ui.write('Succesfully extracted library\n');
+    ui.write('Succesfully extracted library');
     return Promise.resolve();
   });
 };

--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -1,15 +1,14 @@
 /*jshint node:true*/
 'use strict';
 
-var PleasantProgress = require('pleasant-progress');
+var chalk = require('chalk');
+
 
 module.exports = {
-  pleasantProgress: new PleasantProgress(),
-  start: function(msg) {
-    this.pleasantProgress.stop(true);
-    this.pleasantProgress.start(msg);
-  },
   write: function(msg) {
-    this.pleasantProgress.stream.write(msg);
+    console.log(chalk.green(msg));
+  },
+  error: function(msg) {
+    console.log(chalk.red(msg));
   }
 };

--- a/lib/utils/run-command.js
+++ b/lib/utils/run-command.js
@@ -22,8 +22,6 @@ module.exports = function runCommand(command, startedMsg, options) {
 
     return new Promise(function(resolve, reject) {
       exec(command, options, function(err, stdout, stderr) {
-        ui.write('\n');
-
         if (stdout && stdout.length) {
           ui.write(stdout);
         }

--- a/lib/utils/run-command.js
+++ b/lib/utils/run-command.js
@@ -3,7 +3,6 @@
 
 var Promise  = require('../ext/promise');
 var exec     = require('child_process').exec;
-var chalk    = require('chalk');
 var ui       = require('../ui');
 var defaults = require('lodash').defaults;
 
@@ -14,7 +13,7 @@ module.exports = function runCommand(command, startedMsg, options) {
 
   return function() {
     if(startedMsg) {
-      ui.start(chalk.green(startedMsg));
+      ui.write(startedMsg);
     }
 
     options = defaults(options, {
@@ -44,11 +43,10 @@ module.exports = function runCommand(command, startedMsg, options) {
 };
 
 function commandError(command, err) {
-  ui.write(chalk.red('\nError thrown while running shell command: "' + command + '"\n'));
+  ui.error('Error thrown while running shell command: "' + command);
   if(err.stack) {
     ui.write(err.stack);
   } else {
     ui.write(err);
   }
-  ui.write('\n');
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "chalk": "^1.0.0",
     "fs-extra": "^0.19.0",
     "lodash": "^3.9.3",
-    "pleasant-progress": "^1.1.0",
     "rsvp": "^3.0.18"
   },
   "ember-addon": {


### PR DESCRIPTION
- [Asana task: Remove dependency to PrettyProgress](https://app.asana.com/0/26202368814744/38304095006638)

This module is usually used to provide progress reports for tasks that don't execute instantly. Since all of our tasks are instant or near-instant, it only provides overhead with no gains, so I decided to remove it and clean the code up a bit.
