### PR TITLE
Extract to sibling folder

### DIFF
--- a/lib/tasks/extract-component.js
+++ b/lib/tasks/extract-component.js
@@ -6,40 +6,35 @@ var Promise = require('../ext/promise');
 var ui = require('../ui');
 var extractAddon = require('../utils/extract-addon');
 
-function getFilesWithPlaceholdersFromName(name) {
-  return [
-    path.join('addon', name, 'index.js'),
-    path.join('addon', name, 'package.json'),
-    path.join('addon', name, 'style.css')
-  ];
-}
+var placeholder = '<%= componentName %>';
+var blueprintName = 'micro-component';
 
-function getFileMappingsFromName(name) {
-  return [
-    {
-      oldPath: path.join('app', 'components', name + '.js'),
-      newPath: path.join('addon', name, 'component.js')
-    },
-    {
-      oldPath: path.join('app', 'templates/components', name + '.hbs'),
-      newPath: path.join('addon', name, 'template.hbs')
-    },
-    {
-      oldPath: path.join('app', 'styles', name + '.css'),
-      newPath: path.join('addon', name, 'style.css')
-    }
-  ];
-}
+var fileList = ['index.js', 'package.json', 'style.css', 'template.hbs', 'component.js']
 
-module.exports = function(name) {
-  ui.write('Extracting component ' + name + ' into addon/' + name);
+var fileMappings = [
+  {
+    appFile: path.join('app', 'components', placeholder + '.js'),
+    addonFile: 'component.js'
+  },
+  {
+    appFile: path.join('app', 'templates', 'components', placeholder + '.hbs'),
+    addonFile: 'template.hbs'
+  },
+  {
+    appFile: path.join('app', 'styles', placeholder + '.css'),
+    addonFile: 'style.css'
+  }
+]
+
+module.exports = function(addonName) {
+  ui.write('Extracting component ' + addonName + ' into ../' + addonName);
 
   var options = {
-    addonName: name,
-    blueprintName: 'micro-component',
-    placeholder: '<%= componentName %>',
-    filesToReplacePlaceholderIn: getFilesWithPlaceholdersFromName(name),
-    fileMappings: getFileMappingsFromName(name)
+    addonName: addonName,
+    blueprintName: blueprintName,
+    placeholder: placeholder,
+    fileList: fileList,
+    fileMappings: fileMappings
   };
 
   return extractAddon(options).then(function() {

--- a/lib/tasks/extract-helper.js
+++ b/lib/tasks/extract-helper.js
@@ -6,31 +6,27 @@ var path = require('path');
 var ui = require('../ui');
 var extractAddon = require('../utils/extract-addon');
 
-function getFilesWithPlaceholdersFromName(name) {
-  return [
-    path.join('addon', name, 'index.js'),
-    path.join('addon', name, 'package.json'),
-  ];
-}
+var placeholder = '<%= helperName %>';
+var blueprintName = 'micro-helper';
 
-function getFileMappingsFromName(name) {
-  return [
-    {
-      oldPath: path.join('app', 'helpers', name + '.js'),
-      newPath: path.join('addon', name, 'helper.js')
-    }
-  ];
-}
+var fileList = ['index.js', 'package.json', 'helper.js']
 
-module.exports = function(name) {
-  ui.write('Extracting helper ' + name + ' into addon/' + name);
+var fileMappings = [
+  {
+    appFile: path.join('app', 'helpers', placeholder + '.js'),
+    addonFile: 'helper.js'
+  }
+]
+
+module.exports = function(addonName) {
+  ui.write('Extracting helper ' + addonName + ' into ../' + addonName);
 
   var options = {
-    addonName: name,
-    blueprintName: 'micro-helper',
-    placeholder: '<%= helperName %>',
-    filesToReplacePlaceholderIn: getFilesWithPlaceholdersFromName(name),
-    fileMappings: getFileMappingsFromName(name)
+    addonName: addonName,
+    blueprintName: blueprintName,
+    placeholder: placeholder,
+    fileList: fileList,
+    fileMappings: fileMappings
   };
 
   return extractAddon(options).then(function() {

--- a/lib/tasks/extract-library.js
+++ b/lib/tasks/extract-library.js
@@ -6,31 +6,27 @@ var path = require('path');
 var ui = require('../ui');
 var extractAddon = require('../utils/extract-addon');
 
-function getFilesWithPlaceholdersFromName(name) {
-  return [
-    path.join('addon', name, 'index.js'),
-    path.join('addon', name, 'package.json'),
-  ];
-}
+var placeholder = '<%= libraryName %>';
+var blueprintName = 'micro-library';
 
-function getFileMappingsFromName(name) {
-  return [
-    {
-      oldPath: path.join('app', 'lib', name + '.js'),
-      newPath: path.join('addon', name, 'library.js')
-    }
-  ];
-}
+var fileList = ['index.js', 'package.json', 'library.js']
 
-module.exports = function(name) {
-  ui.write('Extracting library ' + name + ' into addon/' + name);
+var fileMappings = [
+  {
+    appFile: path.join('app', 'lib', placeholder + '.js'),
+    addonFile: 'library.js'
+  }
+]
+
+module.exports = function(addonName) {
+  ui.write('Extracting library ' + addonName + ' into ../' + addonName);
 
   var options = {
-    addonName: name,
-    blueprintName: 'micro-library',
-    placeholder: '<%= libraryName %>',
-    filesToReplacePlaceholderIn: getFilesWithPlaceholdersFromName(name),
-    fileMappings: getFileMappingsFromName(name)
+    addonName: addonName,
+    blueprintName: blueprintName,
+    placeholder: placeholder,
+    fileList: fileList,
+    fileMappings: fileMappings
   };
 
   return extractAddon(options).then(function() {

--- a/lib/utils/copy-files.js
+++ b/lib/utils/copy-files.js
@@ -11,6 +11,6 @@ function copyFileIfExists(oldFile, newFile) {
 
 module.exports = function(fileMappings) {
   return Promise.map(fileMappings, function(fileMapping) {
-    return copyFileIfExists(fileMapping.oldPath, fileMapping.newPath);
+    return copyFileIfExists(fileMapping.src, fileMapping.dest);
   });
 };

--- a/lib/utils/extract-addon.js
+++ b/lib/utils/extract-addon.js
@@ -54,14 +54,11 @@ function copyFileIfExists(oldFile, newFile) {
 }
 
 function copyAddonFiles(options) {
-  console.log('options', options);
   var destination = getExtractDestination(options);
-  console.log('destination', destination);
   return Promise.map(options.fileMappings, function(fileMapping) {
-    console.log('destination', destination);
-    console.log('fileMapping', fileMapping);
-    var fullPath = path.join(destination, fileMapping.addonFile)
-    return copyFileIfExists(fileMapping.appFile, fullPath);
+    var sourceFile = fileMapping.appFile.replace(options.placeholder, options.addonName);
+    var destinationFile = path.join(destination, fileMapping.addonFile);
+    return copyFileIfExists(sourceFile, destinationFile);
   });
 };
 

--- a/lib/utils/extract-addon.js
+++ b/lib/utils/extract-addon.js
@@ -4,23 +4,30 @@ var fs = require('fs-extra');
 var path = require('path');
 
 var Promise = require('../ext/promise');
-var copyFiles = require('./copy-files');
 
 var ensureDir = Promise.denodeify(fs.ensureDir);
 var copy = Promise.denodeify(fs.copy);
 var readFile = Promise.denodeify(fs.readFile);
 var writeFile = Promise.denodeify(fs.writeFile);
 
-function createAddonFolder(name) {
-  return ensureDir(path.join('addon', name));
+function getDefaultExtractDestination(addonName) {
+  return path.resolve(path.join('..', addonName));
 }
 
-function copyBlueprintFiles(name, blueprintName) {
+function getExtractDestination(options) {
+  return options.extractDestination || getDefaultExtractDestination(options.addonName);
+}
+
+function createAddonFolder(options) {
+  return ensureDir(getExtractDestination(options));
+}
+
+function copyBlueprintFiles(options) {
   var blueprintFolderRelativePath = "../../blueprints";
-  var blueprintPath = path.resolve(__dirname, blueprintFolderRelativePath, blueprintName);
+  var blueprintPath = path.resolve(__dirname, blueprintFolderRelativePath, options.blueprintName);
 
   var srcPath = path.join(blueprintPath, 'files');
-  var destPath = path.join('addon', name);
+  var destPath = getExtractDestination(options);
 
   return copy(srcPath, destPath);
 }
@@ -32,18 +39,42 @@ function replaceInFile(file, placeholder, value) {
   });
 }
 
-function replaceInFiles(files, placeholder, value) {
-  return Promise.map(files, function(file) {
-    return replaceInFile(file, placeholder, value);
+function replaceInFiles(options) {
+  var basePath = getExtractDestination(options);
+  return Promise.map(options.fileList, function(relativeFilePath) {
+    var absoluteFilePath = path.join(basePath, relativeFilePath);
+    return replaceInFile(absoluteFilePath, options.placeholder, options.addonName);
   });
 }
 
+function copyFileIfExists(oldFile, newFile) {
+  return new Promise(function(resolve) {
+    copy(oldFile, newFile, { clobber: true }).finally(resolve);
+  });
+}
+
+function copyAddonFiles(options) {
+  console.log('options', options);
+  var destination = getExtractDestination(options);
+  console.log('destination', destination);
+  return Promise.map(options.fileMappings, function(fileMapping) {
+    console.log('destination', destination);
+    console.log('fileMapping', fileMapping);
+    var fullPath = path.join(destination, fileMapping.addonFile)
+    return copyFileIfExists(fileMapping.appFile, fullPath);
+  });
+};
+
 module.exports = function(options) {
-  return createAddonFolder(options.addonName).then(function() {
-    return copyBlueprintFiles(options.addonName, options.blueprintName);
+  console.log('creating folder');
+  return createAddonFolder(options).then(function() {
+    console.log('copying blueprint');
+    return copyBlueprintFiles(options);
   }).then(function() {
-    return replaceInFiles(options.filesToReplacePlaceholderIn, options.placeholder, options.addonName);
+    console.log('replacing');
+    return replaceInFiles(options);
   }).then(function () {
-    return copyFiles(options.fileMappings);
+    console.log('copying addon files');
+    return copyAddonFiles(options);
   });
 };


### PR DESCRIPTION
- [Asana task: Make addon extraction go to a sibling path](https://app.asana.com/0/26202368814744/38452187085426)
# Description

This PR changes how addon extraction works.

Previously, if the app was in `~/path/to/my-app`, the extracted addon would go to `~/path/to/my-app/addon/addon-name`. Now, it goes to `~/path/to/addon-name`
