### PR TITLE
Cache credentials

### DIFF
--- a/lib/cli/publish.js
+++ b/lib/cli/publish.js
@@ -1,29 +1,9 @@
 #! /usr/bin/env node
 
 var program = require('commander');
-var cliPrompt = require('prompt');
 
 var dasherize = require('../utils/string').dasherize;
 var ui = require('../ui');
-
-cliPrompt.message = '';
-cliPrompt.delimiter = '';
-
-var promptSchema = {
-  properties: {
-    username: {
-      description: 'GitHub username: ',
-      message: 'A username is required.',
-      required: true
-    },
-    password: {
-      description: 'GitHub password: ',
-      message: 'A password is required.',
-      required: true,
-      hidden: true
-    }
-  }
-};
 
 program
   .arguments('<addonName>')
@@ -48,20 +28,7 @@ function runPublishTask() {
 }
 
 if (program.addonName) {
-  if(program.username && program.password) {
-    runPublishTask();
-  } else {
-    cliPrompt.start();
-    cliPrompt.get(promptSchema, function(error, result) {
-      if (error) {
-        return ui.error(error);
-      } else {
-        program.username = result.username;
-        program.password = result.password;
-        runPublishTask();
-      }
-    });
-  }
+  runPublishTask();
 } else {
   program.outputHelp();
 }

--- a/lib/tasks/publish.js
+++ b/lib/tasks/publish.js
@@ -41,9 +41,7 @@ function addExistingFilesToLocalRepo(localRepo) {
 }
 
 function createInitialCommitOnLocalRepo(options, localRepo, oid) {
-  console.log('creating signature', options);
   var signature = createGitSignature(localRepo);
-  console.log('signature created', signature);
   return localRepo.createCommit("HEAD", signature, signature, "Initial commit", oid, []);
 }
 
@@ -72,7 +70,12 @@ function pushToRepo(options, localRepo, remote) {
 
   remote.setCallbacks({
     credentials: function() {
-      return git.Cred.usernameNew('ember-micro');
+      // the code here is misleading, but it works
+      // usually, we pass in a username and password to the function,
+      // but passing in the two parameters bellow makes the functio work with an
+      // oauth token as well. there is no properly named function
+      // available that does this.
+      return git.Cred.userpassPlaintextNew(options.token, 'x-oauth-basic');
     }
   });
 
@@ -91,17 +94,26 @@ function initializeGitHub(options) {
 
   if (options.username && options.password) {
     authenticateWithUserProvidedCredentials(github,options);
-    return createToken(github).then(gitHubCredentials.setToken).then(function() {
+    return createToken(github).then(function(token) {
+      options.token = token;
+      return gitHubCredentials.setToken(token);
+    }).then(function() {
       return github;
     });
   } else {
     return gitHubCredentials.getToken().then(function(token) {
+      options.token = token;
       authenticateWithToken(github, token);
       return github;
     }).catch(function() {
       return promptForCredentials().then(function(credentials) {
-        authenticateWithUserProvidedCredentials(github, credentials);
-        return createToken(github).then(gitHubCredentials.setToken).then(function() {
+        options.username = credentials.username;
+        options.password = credentials.password;
+        authenticateWithUserProvidedCredentials(github,credentials);
+        return createToken(github).then(function(token) {
+          options.token = token;
+          return gitHubCredentials.setToken(token);
+        }).then(function() {
           return github;
         });
       });

--- a/lib/tasks/publish.js
+++ b/lib/tasks/publish.js
@@ -7,6 +7,7 @@ var GitHubAPI = require('github');
 
 var Promise = require('../ext/promise');
 var ui = require('../ui');
+var gitHubCredentials = require('../utils/github-credentials');
 
 function createGitSignature(options) {
   var millisecondsFromStandardEpoch = Date.now();
@@ -47,11 +48,11 @@ function createInitialCommitOnLocalRepo(options, localRepo, oid) {
   return localRepo.createCommit("HEAD", signature, signature, "Initial commit", oid, []);
 }
 
-function createRemoteRepo(gitHubApi, repoName) {
+function createRemoteRepo(github, repoName) {
   ui.write('Creating remote repository...');
 
   return new Promise(function(resolve, reject) {
-    gitHubApi.repos.create({
+    github.repos.create({
       name: repoName
     }, function(err, result) {
       if (err) {
@@ -64,7 +65,9 @@ function createRemoteRepo(gitHubApi, repoName) {
 }
 
 function addRemoteOrigin(localRepo, remoteRepo) {
-  return git.Remote.create(localRepo, 'origin', remoteRepo.html_url);
+  var result = git.Remote.create(localRepo, 'origin', remoteRepo.html_url);
+  console.log('result', result);
+  return result;
 }
 
 function pushToRepo(options, localRepo, remote) {
@@ -84,33 +87,69 @@ function pushToRepo(options, localRepo, remote) {
   return remote.push(refSpecs, pushOptions, signature, message);
 }
 
-function initializeGitHubAPI() {
-  return new GitHubAPI({
+function initializeGitHub(options) {
+  var github = new GitHubAPI({
     version: '3.0.0',
+  });
+
+  return gitHubCredentials.getToken().then(function(token) {
+    console.log('token exists:', token);
+    authenticateWithToken(github, token);
+    return github;
+  }).catch(function() {
+    console.log('token missing, creating');
+    authenticateWithUserProvidedCredentials(github,options);
+    return createToken(github).then(function() {
+      return github;
+    });
   });
 }
 
-function authenticateGitHubAPI(gitHubApi, options) {
-  gitHubApi.authenticate({
+function authenticateWithToken(github, token) {
+  github.authenticate({
+    type: 'oauth',
+    token: token,
+  });
+}
+
+function authenticateWithUserProvidedCredentials(github, options) {
+  github.authenticate({
     type: 'basic',
     username: options.username,
     password: options.password
   });
 }
 
+function createToken(github) {
+  return new Promise(function(resolve, reject) {
+    github.authorization.create({
+      scopes: ['user', 'public_repo', 'repo', 'repo:status', 'gist'],
+      note: 'ember-micro-addon authorization',
+      note_url: 'https://github.com/coderly/ember-micro-addon',
+      headers: {
+        'X-GitHub-OTP': 'two-factor-code'
+      },
+    }, function(err, res) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(res.token);
+      }
+    });
+  });
+}
+
 module.exports = function(options) {
   options.workingDirectory = path.join(process.cwd(), options.addonName);
 
-  var gitHubApi = initializeGitHubAPI();
-
-  authenticateGitHubAPI(gitHubApi, options);
-
-  ui.write('Publishing ' + options.addonName + ' to GitHub...');
-  return createLocalRepo(options).then(function(localRepo) {
-    return createRemoteRepo(gitHubApi, options.addonName).then(function(remoteRepo) {
-      return addRemoteOrigin(localRepo, remoteRepo);
-    }).then(function(remoteResult) {
-      return pushToRepo(options, localRepo, remoteResult);
+  return initializeGitHub(options).then(function(github) {
+    ui.write('Publishing ' + options.addonName + ' to GitHub...');
+    return createLocalRepo(options).then(function(localRepo) {
+      return createRemoteRepo(github, options.addonName).then(function(remoteRepo) {
+        return addRemoteOrigin(localRepo, remoteRepo);
+      }).then(function(remoteResult) {
+        return pushToRepo(options, localRepo, remoteResult);
+      });
     });
   });
 

--- a/lib/tasks/publish.js
+++ b/lib/tasks/publish.js
@@ -8,12 +8,10 @@ var GitHubAPI = require('github');
 var Promise = require('../ext/promise');
 var ui = require('../ui');
 var gitHubCredentials = require('../utils/github-credentials');
+var promptForCredentials = require('../utils/credentials-prompt');
 
-function createGitSignature(options) {
-  var millisecondsFromStandardEpoch = Date.now();
-  var secondsFromStandardEpoch = Math.floor(millisecondsFromStandardEpoch / 1000);
-
-  return git.Signature.create('ember-micro', options.username, secondsFromStandardEpoch, 60);
+function createGitSignature(repo) {
+  return git.Signature.default(repo);
 }
 
 function createLocalRepo(options) {
@@ -43,8 +41,9 @@ function addExistingFilesToLocalRepo(localRepo) {
 }
 
 function createInitialCommitOnLocalRepo(options, localRepo, oid) {
-  var signature = createGitSignature(options);
-
+  console.log('creating signature', options);
+  var signature = createGitSignature(localRepo);
+  console.log('signature created', signature);
   return localRepo.createCommit("HEAD", signature, signature, "Initial commit", oid, []);
 }
 
@@ -73,7 +72,7 @@ function pushToRepo(options, localRepo, remote) {
 
   remote.setCallbacks({
     credentials: function() {
-      return git.Cred.userpassPlaintextNew(options.username, options.password);
+      return git.Cred.usernameNew('ember-micro');
     }
   });
 
@@ -90,17 +89,24 @@ function initializeGitHub(options) {
     version: '3.0.0',
   });
 
-  return gitHubCredentials.getToken().then(function(token) {
-    console.log('token exists:', token);
-    authenticateWithToken(github, token);
-    return github;
-  }).catch(function() {
-    console.log('token missing, creating');
+  if (options.username && options.password) {
     authenticateWithUserProvidedCredentials(github,options);
     return createToken(github).then(gitHubCredentials.setToken).then(function() {
       return github;
     });
-  });
+  } else {
+    return gitHubCredentials.getToken().then(function(token) {
+      authenticateWithToken(github, token);
+      return github;
+    }).catch(function() {
+      return promptForCredentials().then(function(credentials) {
+        authenticateWithUserProvidedCredentials(github, credentials);
+        return createToken(github).then(gitHubCredentials.setToken).then(function() {
+          return github;
+        });
+      });
+    });
+  }
 }
 
 function authenticateWithToken(github, token) {
@@ -122,7 +128,7 @@ function createToken(github) {
   return new Promise(function(resolve, reject) {
     github.authorization.create({
       scopes: ['user', 'public_repo', 'repo', 'repo:status', 'gist'],
-      note: 'ember-micro-addon authorization',
+      note: 'ember-micro-addon@' + Date.now(),
       note_url: 'https://github.com/coderly/ember-micro-addon',
       headers: {
         'X-GitHub-OTP': 'two-factor-code'

--- a/lib/tasks/publish.js
+++ b/lib/tasks/publish.js
@@ -65,9 +65,7 @@ function createRemoteRepo(github, repoName) {
 }
 
 function addRemoteOrigin(localRepo, remoteRepo) {
-  var result = git.Remote.create(localRepo, 'origin', remoteRepo.html_url);
-  console.log('result', result);
-  return result;
+  return git.Remote.create(localRepo, 'origin', remoteRepo.html_url);
 }
 
 function pushToRepo(options, localRepo, remote) {
@@ -99,7 +97,7 @@ function initializeGitHub(options) {
   }).catch(function() {
     console.log('token missing, creating');
     authenticateWithUserProvidedCredentials(github,options);
-    return createToken(github).then(function() {
+    return createToken(github).then(gitHubCredentials.setToken).then(function() {
       return github;
     });
   });

--- a/lib/utils/credentials-prompt.js
+++ b/lib/utils/credentials-prompt.js
@@ -26,10 +26,8 @@ module.exports = function promptForCredentials() {
   return new Promise(function(resolve, reject) {
     cliPrompt.get(promptSchema, function(error, result) {
       if (error) {
-        console.log('prompt error', error);
         reject(error);
       } else {
-        console.log('prompt success', result);
         resolve(result);
       }
     });

--- a/lib/utils/credentials-prompt.js
+++ b/lib/utils/credentials-prompt.js
@@ -1,0 +1,37 @@
+var cliPrompt = require('prompt');
+
+cliPrompt.message = '';
+cliPrompt.delimiter = '';
+
+var promptSchema = {
+  properties: {
+    username: {
+      description: 'GitHub username: ',
+      message: 'A username is required.',
+      required: true
+    },
+    password: {
+      description: 'GitHub password: ',
+      message: 'A password is required.',
+      required: true,
+      hidden: true
+    }
+  }
+};
+
+var Promise = require('../ext/promise');
+
+module.exports = function promptForCredentials() {
+  cliPrompt.start();
+  return new Promise(function(resolve, reject) {
+    cliPrompt.get(promptSchema, function(error, result) {
+      if (error) {
+        console.log('prompt error', error);
+        reject(error);
+      } else {
+        console.log('prompt success', result);
+        resolve(result);
+      }
+    });
+  });
+};

--- a/lib/utils/github-credentials.js
+++ b/lib/utils/github-credentials.js
@@ -4,13 +4,12 @@ var storage = require('node-persist');
 var path = require('path');
 
 var TOKEN_KEY = 'ember-micro-github-token';
-var CREDENTIAL_FOLDER =+ '.ember-micro-addon-credentials';
+var CREDENTIAL_FOLDER = '.ember-micro-addon-credentials';
 
 var Promise = require('../ext/promise');
-var initStorage = Promise.denodeify(storage.init);
 var setItem = Promise.denodeify(storage.setItem);
 var getItem = Promise.denodeify(storage.getItem);
-var persist = Promise.denodeify(storage.persist);
+
 
 var cachedToken;
 
@@ -19,22 +18,19 @@ function getUserHome() {
   return path.join(userHome, CREDENTIAL_FOLDER);
 }
 
+storage.initSync({ dir: getUserHome() });
+
 module.exports = {
   setToken: function(token) {
     cachedToken = token;
-    initStorage({ dir: getUserHome() }).then(function () {
-      console.log('storing token', TOKEN_KEY, token);
-      setItem(TOKEN_KEY, token).then(persist);
-    });
+    return setItem(TOKEN_KEY, token);
   },
   getToken: function() {
     return new Promise(function(resolve) {
       if (cachedToken) {
         resolve(cachedToken);
       } else {
-        initStorage({ dir: getUserHome() }).then(function() {
-          return getItem(TOKEN_KEY);
-        }).then(resolve);
+        return getItem(TOKEN_KEY).then(resolve);
       }
     });
   }

--- a/lib/utils/github-credentials.js
+++ b/lib/utils/github-credentials.js
@@ -1,0 +1,41 @@
+/* jshint node:true*/
+
+var storage = require('node-persist');
+var path = require('path');
+
+var TOKEN_KEY = 'ember-micro-github-token';
+var CREDENTIAL_FOLDER =+ '.ember-micro-addon-credentials';
+
+var Promise = require('../ext/promise');
+var initStorage = Promise.denodeify(storage.init);
+var setItem = Promise.denodeify(storage.setItem);
+var getItem = Promise.denodeify(storage.getItem);
+var persist = Promise.denodeify(storage.persist);
+
+var cachedToken;
+
+function getUserHome() {
+  var userHome = process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'];
+  return path.join(userHome, CREDENTIAL_FOLDER);
+}
+
+module.exports = {
+  setToken: function(token) {
+    cachedToken = token;
+    initStorage({ dir: getUserHome() }).then(function () {
+      console.log('storing token', TOKEN_KEY, token);
+      setItem(TOKEN_KEY, token).then(persist);
+    });
+  },
+  getToken: function() {
+    return new Promise(function(resolve) {
+      if (cachedToken) {
+        resolve(cachedToken);
+      } else {
+        initStorage({ dir: getUserHome() }).then(function() {
+          return getItem(TOKEN_KEY);
+        }).then(resolve);
+      }
+    });
+  }
+};

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "fs-extra": "^0.19.0",
     "github": "^0.2.4",
     "lodash": "^3.9.3",
+    "node-persist": "0.0.4",
     "nodegit": "^0.4.1",
     "prompt": "^0.2.14",
     "rsvp": "^3.0.18"


### PR DESCRIPTION
- [Asana task: Publish command should cache credentials](https://app.asana.com/0/26202368814744/40013914538385)
# Description

This PR enables caching of credentials required for the publish command. 
## Behavior

The behavior is different depending on how the command is executed.

`ember-micro:publish addonName -u username -p password`

Username and password are provided. A new token will be created and stored in the file system.

`ember-micro:publish adddonName`

Username and password are not provided. The application will attempt to load a stored token from the file system.

If a token is found, it will be used to authorize.

If a token is not found, the user will be prompted for a username and password. Once those are provided, a new token will be created and stored in the file system.
# Issues

The created token is stored on the github account. In most cases, there will only ever be a few tokens created by ember-micro-addon, but in some cases, it may be considered a bit spammy.

Is this approach acceptable, or should I look into somehow making it less spammy? We can't really retrieve an existing token. We can retrieve the data for it, but the token itself is not returned, only the hash for it, and the last 8 characters.

The only way I think this is possible is to register the app and use a secret/public key system, but even then, I'm not sure if it's possible to avoid creating multiple tokens.

An alternative is to not use a token at all and store username/password credentials locally, but that sounds very unsafe.
