### PR TITLE
Added optional path option to extract command

### DIFF
--- a/lib/cli/extract.js
+++ b/lib/cli/extract.js
@@ -1,43 +1,55 @@
 #! /usr/bin/env node
 
 var program = require('commander');
+var path = require('path');
 
 var dasherize = require('../utils/string').dasherize;
-var Promise = require('../ext/promise');
 var ui = require('../ui');
 
 var options = {};
+var task;
 
 program
-  .usage('<addonType> <addonName>');
+  .usage('<addonType> <addonName>')
+  .option('-d, --destination <destination>', 'Extract destination');
 
 program
   .command('library <addonName>')
   .description('Extract a library')
   .action(function(addonName) {
     options.addonName = addonName ? dasherize(addonName) : null;
-    require('../tasks/extract-library')(options).catch(ui.error);
+    task = require('../tasks/extract-library');
   });
+
 
 program
   .command('helper <addonName>')
   .description('Extract a helper')
   .action(function(addonName) {
     options.addonName = addonName ? dasherize(addonName) : null;
-    require('../tasks/extract-helper')(options).catch(ui.error);
+    task = require('../tasks/extract-helper');
   });
+
 
 program
   .command('component <addonName>')
   .description('Extract a component')
   .action(function(addonName) {
     options.addonName = addonName ? dasherize(addonName) : null;
-    require('../tasks/extract-component')(options).catch(ui.error);
+    task = require('../tasks/extract-component');
   });
+
 
 program
   .parse(process.argv);
 
 if (process.argv.length < 3) {
   program.outputHelp();
+} else {
+  options.destination = program.destination || getDefaultExtractDestination(options.addonName);
+  task(options).catch(ui.error);
+}
+
+function getDefaultExtractDestination(addonName) {
+  return path.resolve(path.join('..', addonName));
 }

--- a/lib/tasks/extract-component.js
+++ b/lib/tasks/extract-component.js
@@ -26,7 +26,7 @@ var fileMappings = [
 ];
 
 module.exports = function(options) {
-  ui.write('Extracting component ' + options.addonName + ' into ../' + options.addonName);
+  ui.write('Extracting component ' + options.addonName + ' into ' + options.destination);
 
   options.blueprintName = blueprintName;
   options.placeholder = placeholder;

--- a/lib/tasks/extract-helper.js
+++ b/lib/tasks/extract-helper.js
@@ -18,7 +18,7 @@ var fileMappings = [
 ];
 
 module.exports = function(options) {
-  ui.write('Extracting helper ' + options.addonName + ' into ../' + options.addonName);
+  ui.write('Extracting helper ' + options.addonName + ' into ' + options.destination);
 
   options.blueprintName = blueprintName;
   options.placeholder = placeholder;

--- a/lib/tasks/extract-library.js
+++ b/lib/tasks/extract-library.js
@@ -18,7 +18,7 @@ var fileMappings = [
 ];
 
 module.exports = function(options) {
-  ui.write('Extracting library ' + options.addonName + ' into ../' + options.addonName);
+  ui.write('Extracting library ' + options.addonName + ' into ' + options.destination);
 
   options.blueprintName = blueprintName;
   options.placeholder = placeholder;

--- a/lib/utils/extract-addon.js
+++ b/lib/utils/extract-addon.js
@@ -10,16 +10,8 @@ var copy = Promise.denodeify(fs.copy);
 var readFile = Promise.denodeify(fs.readFile);
 var writeFile = Promise.denodeify(fs.writeFile);
 
-function getDefaultExtractDestination(addonName) {
-  return path.resolve(path.join('..', addonName));
-}
-
-function getExtractDestination(options) {
-  return options.extractDestination || getDefaultExtractDestination(options.addonName);
-}
-
 function createAddonFolder(options) {
-  return ensureDir(getExtractDestination(options));
+  return ensureDir(options.destination);
 }
 
 function copyBlueprintFiles(options) {
@@ -27,7 +19,7 @@ function copyBlueprintFiles(options) {
   var blueprintPath = path.resolve(__dirname, blueprintFolderRelativePath, options.blueprintName);
 
   var srcPath = path.join(blueprintPath, 'files');
-  var destPath = getExtractDestination(options);
+  var destPath = options.destination;
 
   return copy(srcPath, destPath);
 }
@@ -40,7 +32,7 @@ function replaceInFile(file, placeholder, value) {
 }
 
 function replaceInFiles(options) {
-  var basePath = getExtractDestination(options);
+  var basePath = options.destination;
   return Promise.map(options.fileList, function(relativeFilePath) {
     var absoluteFilePath = path.join(basePath, relativeFilePath);
     return replaceInFile(absoluteFilePath, options.placeholder, options.addonName);
@@ -54,7 +46,7 @@ function copyFileIfExists(oldFile, newFile) {
 }
 
 function copyAddonFiles(options) {
-  var destination = getExtractDestination(options);
+  var destination = options.destination;
   return Promise.map(options.fileMappings, function(fileMapping) {
     var sourceFile = fileMapping.appFile.replace(options.placeholder, options.addonName);
     var destinationFile = path.join(destination, fileMapping.addonFile);


### PR DESCRIPTION
- [Asana task: Allow specifying path for extract command](https://app.asana.com/0/26202368814744/40302537333134)
# Description

This PR adds an option to set the destination path to the extract command

The usage now is

`ember-micro:extract addonType addonName --destination|-d destination`

The switch is optional and in cases where it isn't provided, the command defaults to the previous default path - a sibling of the app folder.
