### PR TITLE
Removed manual support of micro-addons.

### DIFF
--- a/blueprints/micro-component/files/index.js
+++ b/blueprints/micro-component/files/index.js
@@ -1,42 +1,6 @@
 /* jshint node: true */
 'use strict';
 
-var path = require('path');
-var Funnel = require('broccoli-funnel');
-
 module.exports = {
   name: '<%= componentName %>',
-
-  treeForApp: function() {
-    return this.buildTree(this.root, ['component.js']);
-  },
-
-  treeForTemplates: function() {
-    return this.buildTree(this.root, ['template.hbs']);
-  },
-
-  treeForAddon: function() {
-    return this.buildTree(this.root, ['style.css']);
-  },
-
-  buildTree: function(sourceTree, includedFiles) {
-    var addon = this;
-
-    return new Funnel(sourceTree, {
-      include: includedFiles,
-      getDestinationPath: function(relativePath) {
-        return addon.mapFile(relativePath);
-      }
-    });
-  },
-
-  mapFile: function(relativePath) {
-    if (relativePath === 'component.js') {
-      return path.join('components', this.name + '.js');
-    } else if (relativePath === 'template.hbs') {
-      return path.join('components', this.name + '.hbs');
-    } else if (relativePath === 'style.css') {
-      return path.join('addon/styles', this.name + '.css');
-    }
-  }
 };

--- a/blueprints/micro-component/files/package.json
+++ b/blueprints/micro-component/files/package.json
@@ -6,9 +6,6 @@
   "engines": {
     "node": ">= 0.10.0"
   },
-  "dependencies": {
-    "broccoli-funnel": "^0.2.3"
-  },
   "keywords": [
     "ember-addon",
     "ember-micro-addon",

--- a/blueprints/micro-helper/files/index.js
+++ b/blueprints/micro-helper/files/index.js
@@ -1,30 +1,6 @@
 /* jshint node: true */
 'use strict';
 
-var path = require('path');
-var Funnel = require('broccoli-funnel');
-
 module.exports = {
   name: '<%= helperName %>',
-
-  treeForApp: function() {
-    return this.buildTree(this.root, ['helper.js']);
-  },
-
-  buildTree: function(sourceTree, includedFiles) {
-    var addon = this;
-
-    return new Funnel(sourceTree, {
-      include: includedFiles,
-      getDestinationPath: function(relativePath) {
-        return addon.mapFile(relativePath);
-      }
-    });
-  },
-
-  mapFile: function(relativePath) {
-    if (relativePath === 'helper.js') {
-      return path.join('helpers', this.name + '.js');
-    }
-  }
 };

--- a/blueprints/micro-helper/files/package.json
+++ b/blueprints/micro-helper/files/package.json
@@ -6,9 +6,6 @@
   "engines": {
     "node": ">= 0.10.0"
   },
-  "dependencies": {
-    "broccoli-funnel": "^0.2.3"
-  },
   "keywords": [
     "ember-addon",
     "ember-micro-addon",

--- a/blueprints/micro-library/files/index.js
+++ b/blueprints/micro-library/files/index.js
@@ -1,30 +1,6 @@
 /* jshint node: true */
 'use strict';
 
-var path = require('path');
-var Funnel = require('broccoli-funnel');
-
 module.exports = {
   name: '<%= libraryName %>',
-
-  treeForApp: function() {
-    return this.buildTree(this.root, ['library.js']);
-  },
-
-  buildTree: function(sourceTree, includedFiles) {
-    var addon = this;
-
-    return new Funnel(sourceTree, {
-      include: includedFiles,
-      getDestinationPath: function(relativePath) {
-        return addon.mapFile(relativePath);
-      }
-    });
-  },
-
-  mapFile: function(relativePath) {
-    if (relativePath === 'library.js') {
-      return path.join('lib', this.name + '.js');
-    }
-  }
 };

--- a/blueprints/micro-library/files/package.json
+++ b/blueprints/micro-library/files/package.json
@@ -6,9 +6,6 @@
   "engines": {
     "node": ">= 0.10.0"
   },
-  "dependencies": {
-    "broccoli-funnel": "^0.2.3"
-  },
   "keywords": [
     "ember-addon",
     "ember-micro-addon",


### PR DESCRIPTION
- [Asana task: Remove manual support of micro-addons from ember-micro-addons](https://app.asana.com/0/26202368814744/41316779699482)
# Description

This PR removes code required to make micro-addons work within an ember-CLI application.

The idea is that ember-CLI itself will support micro-addons, so it should be the one doing it. This library will instead simply offer tools to generate, extract and publish micro-addons.

This branch probably wont get merged for a while. We need to merge micro-addon support into ember-CLI first.

There is no PR in ember-CLI yet, but it will be linked here when it's available.
