### PR TITLE
Moved micro-library to make it accessible from the addon namespace

### DIFF
--- a/blueprints/micro-library/files/index.js
+++ b/blueprints/micro-library/files/index.js
@@ -7,8 +7,9 @@ var Funnel = require('broccoli-funnel');
 module.exports = {
   name: '<%= libraryName %>',
 
-  treeForApp: function() {
-    return this.buildTree(this.root, ['library.js']);
+  treeForAddon: function() {
+    var addonTree = this.buildTree(this.root, ['library.js']);
+    return this.compileAddon(addonTree);
   },
 
   buildTree: function(sourceTree, includedFiles) {


### PR DESCRIPTION
- [Asana task: Update ember-micro-addon libraries so they're consistent with the way it's done in the Ember-CLI PR](https://app.asana.com/0/26202368814744/41602579687439)
# Description

This PR reworks how a micro-library is generated.

The end result is that, at build time, `library.js` gets renamed to `addon-name.js` and copied into `addon/lib/addon-name.js`. This makes it available for import from the addon namespace(`'addon-name/lib/addon-name'`), where it was previously available for import from the app namespace(`'app-name/lib/addon-name'`).

This is in compliance with the proposal I wrote (#30) as well as an Ember-CLI PR (coderly/ember-cli#1). 
